### PR TITLE
change drop-role-handling and add support for set-account-alias

### DIFF
--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -67,9 +67,11 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
     boto3.DEFAULT_SESSION = None
     # account_id = get_account_id(session['account'])
     # info('Account ID is {}'.format(account_id))
-
+    isProfileSession = 'profile_name' in session_data.session
     account_alias_from_aws = get_account_alias(account.session)
-    if account.alias != account_alias_from_aws:
+    if len(account_alias_from_aws) == 0:
+        set_account_alias(account.session, account.alias)
+    elif account.alias != account_alias_from_aws[0]:
         error('Connected to "{}", but account "{}" should be configured'.format(account_alias_from_aws, account.alias))
         return
 
@@ -78,7 +80,7 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
 
     configure_cloudtrail_all_regions(account)
     dns_domain = configure_dns(account)
-    configure_iam(account, dns_domain)
+    configure_iam(account, dns_domain, isProfileSession)
     configure_s3_buckets(account)
     configure_ses(account, dns_domain)
 
@@ -138,7 +140,7 @@ def cleanup_account(session_data: AccountData, region: str):
     # info('Account ID is {}'.format(account_id))
 
     account_alias_from_aws = get_account_alias(account.session)
-    if account.alias != account_alias_from_aws:
+    if len(account_alias_from_aws) > 0 and account.alias != account_alias_from_aws[0]:
         error('Connected to "{}", but account "{}" should be configured'.format(account_alias_from_aws, account.alias))
         return
 

--- a/sevenseconds/helper/aws.py
+++ b/sevenseconds/helper/aws.py
@@ -12,7 +12,12 @@ def filter_subnets(vpc: object, _type: str):
 
 def get_account_alias(session):
     conn = session.client('iam')
-    return conn.list_account_aliases()['AccountAliases'][0]
+    return conn.list_account_aliases()['AccountAliases']
+
+
+def set_account_alias(session, alias):
+    conn = session.client('iam')
+    conn.create_account_alias(AccountAlias=alias)
 
 
 def get_account_id(session):


### PR DESCRIPTION
* add support for iam role "only_unused" and drop role only if this a session without credentials profile
* set account alias if the alias not set (needed for new AWS Organizations accounts)