### PR TITLE
change drop-role-handling and add support for set-account-alias

### DIFF
--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -67,7 +67,6 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
     boto3.DEFAULT_SESSION = None
     # account_id = get_account_id(session['account'])
     # info('Account ID is {}'.format(account_id))
-    is_profile_session = 'profile_name' in session_data.session
     account_alias_from_aws = get_account_alias(account.session)
     if len(account_alias_from_aws) == 0:
         set_account_alias(account.session, account.alias)
@@ -80,7 +79,7 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
 
     configure_cloudtrail_all_regions(account)
     dns_domain = configure_dns(account)
-    configure_iam(account, dns_domain, is_profile_session)
+    configure_iam(account, dns_domain)
     configure_s3_buckets(account)
     configure_ses(account, dns_domain)
 

--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 import time
 from datetime import timedelta
 from ..helper import error, info, ok
-from ..helper.aws import get_account_id, get_account_alias
+from ..helper.aws import get_account_id, get_account_alias, set_account_alias
 from .policysimulator import check_policy_simulator
 from .cloudtrail import configure_cloudtrail_all_regions
 from .route53 import configure_dns
@@ -67,9 +67,11 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
     boto3.DEFAULT_SESSION = None
     # account_id = get_account_id(session['account'])
     # info('Account ID is {}'.format(account_id))
-
+    isProfileSession = 'profile_name' in session_data.session
     account_alias_from_aws = get_account_alias(account.session)
-    if account.alias != account_alias_from_aws:
+    if len(account_alias_from_aws) == 0:
+        set_account_alias(account.session, account.alias)
+    elif account.alias != account_alias_from_aws[0]:
         error('Connected to "{}", but account "{}" should be configured'.format(account_alias_from_aws, account.alias))
         return
 
@@ -78,7 +80,7 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
 
     configure_cloudtrail_all_regions(account)
     dns_domain = configure_dns(account)
-    configure_iam(account, dns_domain)
+    configure_iam(account, dns_domain, isProfileSession)
     configure_s3_buckets(account)
     configure_ses(account, dns_domain)
 
@@ -138,7 +140,7 @@ def cleanup_account(session_data: AccountData, region: str):
     # info('Account ID is {}'.format(account_id))
 
     account_alias_from_aws = get_account_alias(account.session)
-    if account.alias != account_alias_from_aws:
+    if len(account_alias_from_aws) > 0 and account.alias != account_alias_from_aws[0]:
         error('Connected to "{}", but account "{}" should be configured'.format(account_alias_from_aws, account.alias))
         return
 

--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -67,7 +67,7 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
     boto3.DEFAULT_SESSION = None
     # account_id = get_account_id(session['account'])
     # info('Account ID is {}'.format(account_id))
-    isProfileSession = 'profile_name' in session_data.session
+    is_profile_session = 'profile_name' in session_data.session
     account_alias_from_aws = get_account_alias(account.session)
     if len(account_alias_from_aws) == 0:
         set_account_alias(account.session, account.alias)
@@ -80,7 +80,7 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
 
     configure_cloudtrail_all_regions(account)
     dns_domain = configure_dns(account)
-    configure_iam(account, dns_domain, isProfileSession)
+    configure_iam(account, dns_domain, is_profile_session)
     configure_s3_buckets(account)
     configure_ses(account, dns_domain)
 

--- a/sevenseconds/config/iam.py
+++ b/sevenseconds/config/iam.py
@@ -3,7 +3,7 @@ import gnupg
 import json
 import requests
 from ..helper import fatal_error, info, ActionOnExit, error
-from pprint import pprint
+
 
 def configure_iam(account: object, dns_domain: str):
     configure_iam_policy(account)

--- a/sevenseconds/config/iam.py
+++ b/sevenseconds/config/iam.py
@@ -5,13 +5,13 @@ import requests
 from ..helper import fatal_error, info, ActionOnExit, error
 
 
-def configure_iam(account: object, dns_domain: str, isProfileSession: bool):
-    configure_iam_policy(account, isProfileSession)
+def configure_iam(account: object, dns_domain: str, is_profile_session: bool):
+    configure_iam_policy(account, is_profile_session)
     configure_iam_saml(account)
     configure_iam_certificate(account.session, dns_domain)
 
 
-def configure_iam_policy(account: object, isProfileSession: bool):
+def configure_iam_policy(account: object, is_profile_session: bool):
     iam = account.session.resource('iam')
     roles = account.config.get('roles', {})
 
@@ -19,7 +19,7 @@ def configure_iam_policy(account: object, isProfileSession: bool):
 
     for role_name, role_cfg in sorted(roles.items()):
         if role_cfg.get('drop', False):
-            if role_cfg.get('only_unused', False) and isProfileSession:
+            if role_cfg.get('only_unused', False) and is_profile_session:
                 pass
             else:
                 with ActionOnExit('Drop Role {role_name} if exist..', **vars()) as act:

--- a/sevenseconds/helper/aws.py
+++ b/sevenseconds/helper/aws.py
@@ -1,5 +1,3 @@
-from ..helper import ActionOnExit
-
 AZ_NAMES_BY_REGION = {}
 PENDING_ASSOCIATIONS = {}
 

--- a/sevenseconds/helper/aws.py
+++ b/sevenseconds/helper/aws.py
@@ -21,32 +21,8 @@ def set_account_alias(session, alias):
 
 
 def get_account_id(session):
-    conn = session.client('iam')
-    try:
-        own_user = conn.get_user()['User']
-    except:
-        own_user = None
-    if not own_user:
-        roles = conn.list_roles()['Roles']
-        if not roles:
-            users = conn.list_users()['Users']
-            if not users:
-                with ActionOnExit('Creating temporary IAM role to determine account ID..'):
-                    temp_role_name = 'temp-sevenseconds-account-id'
-                    temp_policy = '''{'Statement': [{'Action': ['sts:AssumeRole'],
-                                                  'Effect': 'Allow',
-                                                  'Principal': {'Service': ['ec2.amazonaws.com']}}]}'''
-                    res = conn.create_role(RoleName=temp_role_name, AssumeRolePolicyDocument=temp_policy)
-                    arn = res['Role']['Arn']
-                    conn.delete_role(RoleName=temp_role_name)
-            else:
-                arn = [u['Arn'] for u in users][0]
-        else:
-            arn = [r['Arn'] for r in roles][0]
-    else:
-        arn = own_user['Arn']
-    account_id = arn.split(':')[4]
-    return account_id
+    sts = session.client('sts')
+    return sts.get_caller_identity()['Account']
 
 
 def get_az_names(session, region: str):

--- a/sevenseconds/helper/aws.py
+++ b/sevenseconds/helper/aws.py
@@ -12,7 +12,12 @@ def filter_subnets(vpc: object, _type: str):
 
 def get_account_alias(session):
     conn = session.client('iam')
-    return conn.list_account_aliases()['AccountAliases'][0]
+    return conn.list_account_aliases()['AccountAliases']
+
+
+def set_account_alias(session, alias):
+    conn = session.client('iam')
+    conn.create_account_alias(AccountAlias=alias)
 
 
 def get_account_id(session):

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -7,102 +7,12 @@ import botocore.exceptions
 
 
 def test_get_account_id(monkeypatch):
-    conn = MagicMock(get_user=lambda: {'User': {
-        'Path': '/',
-        'UserName': 'test',
-        'UserId': 'AIABCDEFG',
-        'Arn': 'arn:aws:iam::01234567:user/test',
-        'CreateDate': datetime(2015, 1, 1),
-        'PasswordLastUsed': datetime(2015, 1, 1)
-        }})
-    session = MagicMock(client=MagicMock(return_value=conn))
+    sts = MagicMock(get_caller_identity=lambda: {'Account': '01234567',
+        'Arn': 'arn:aws:iam::01234567:assumed-role/Administrator/sevenseconds',
+        'UserId': 'ABCDEFGHIJKLMNOPQ:sevenseconds'})
+    session = MagicMock(client=MagicMock(return_value=sts))
     id = get_account_id(session)
     assert id == '01234567', 'ID from current User'
-
-    conn = MagicMock(
-        get_user=MagicMock(side_effect=botocore.exceptions.ClientError({
-            'Error': {
-                'Code': 'ValidationError',
-                'Message': 'Must specify userName when calling with non-User credentials'}},
-            'GetUser')),
-        list_roles=lambda: {
-            'Roles': [
-                {
-                    'Path': '/',
-                    'RoleName': 'test-role',
-                    'RoleId': 'string',
-                    'Arn': 'arn:aws:iam::01234567:role/test-role',
-                    'CreateDate': datetime(2015, 1, 1),
-                    'AssumeRolePolicyDocument': {
-                        'Statement': [{
-                            'Action': 'sts:AssumeRole',
-                            'Effect': 'Allow',
-                            'Principal': {'Service': 'ec2.amazonaws.com'},
-                            'Sid': ''}],
-                        'Version': '2008-10-17'}
-                }],
-            'IsTruncated': False,
-            'NextToken': 'string'
-        })
-    session = MagicMock(client=MagicMock(return_value=conn))
-    id = get_account_id(session)
-    assert id == '01234567', 'ID from exisiting Role'
-
-    conn = MagicMock(
-        get_user=MagicMock(side_effect=botocore.exceptions.ClientError({
-            'Error': {
-                'Code': 'ValidationError',
-                'Message': 'Must specify userName when calling with non-User credentials'}},
-            'GetUser')),
-        list_roles=lambda: {
-            'Roles': [],
-            'IsTruncated': False,
-            'NextToken': 'string'},
-        list_users=lambda: {
-            'IsTruncated': False,
-            'Users': [{
-                'Arn': 'arn:aws:iam::1234567:user/test',
-                'CreateDate': datetime(2015, 1, 1),
-                'Path': '/',
-                'UserId': 'AIABCEFG',
-                'UserName': 'test'}]})
-    session = MagicMock(client=MagicMock(return_value=conn))
-    id = get_account_id(session)
-    assert id == '1234567', 'ID from existing Users'
-
-    conn = MagicMock(
-        get_user=MagicMock(side_effect=botocore.exceptions.ClientError({
-            'Error': {
-                'Code': 'ValidationError',
-                'Message': 'Must specify userName when calling with non-User credentials'}},
-            'GetUser')),
-        list_roles=lambda: {
-            'Roles': [],
-            'IsTruncated': False,
-            'NextToken': 'string'},
-        list_users=lambda: {
-            'IsTruncated': False,
-            'Users': []},
-        create_role=lambda RoleName, AssumeRolePolicyDocument: {
-            'Role': {
-                'AssumeRolePolicyDocument': {
-                    'Statement': [
-                        {
-                            'Principal': {'Service': ['ec2.amazonaws.com']},
-                            'Effect': 'Allow',
-                            'Action': ['sts:AssumeRole']
-                        }]
-                    },
-                'RoleName': 'temp-sevenseconds-account-id',
-                'Path': '/',
-                'Arn': 'arn:aws:iam::01234567:role/temp-sevenseconds-account-id',
-                'CreateDate': datetime(2015, 1, 1),
-                'RoleId': 'string'}}
-        )
-
-    session = MagicMock(client=MagicMock(return_value=conn))
-    id = get_account_id(session)
-    assert id == '01234567', 'ID from temporay Role'
 
 
 def test_get_az_names(monkeypatch):


### PR DESCRIPTION
* add support for iam role "only_unused" and drop role only if this a session without credentials profile
* set account alias if the alias not set (needed for new AWS Organizations accounts)