### PR TITLE
fix token and error handling

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -79,8 +79,8 @@ def configure(file, account_name_pattern, **options):
             file,
             account_name_pattern,
             options)
-    except:
-        exit(1)
+    except Exception as e:
+        fatal_error("Can't get sessions. Error: {}".format(e))
 
     # Get NAT/ODD Addresses. Need the first Session to get all AZ for the Regions
     trusted_addresses = get_trusted_addresses(list(sessions.values())[0].admin_session, config)
@@ -122,8 +122,8 @@ def clear_region(file, region, account_name_pattern, **options):
             file,
             account_name_pattern,
             options)
-    except:
-        exit(1)
+    except Exception as e:
+        fatal_error("Can't get sessions. Error: {}".format(e))
 
     start_cleanup(region, sessions, options)
 
@@ -140,8 +140,8 @@ def cli_update_security_group(file, region, account_name_pattern, security_group
             'update Secuity Group in region {} for '.format(region),
             file,
             [account_name_pattern])
-    except:
-        exit(1)
+    except Exception as e:
+        fatal_error("Can't get sessions. Error: {}".format(e))
     addresses = get_trusted_addresses(list(sessions.values())[0].admin_session, config)
     info(', '.join(sorted(addresses)))
     fatal_error('not implemented yet')

--- a/sevenseconds/helper/auth.py
+++ b/sevenseconds/helper/auth.py
@@ -27,7 +27,7 @@ class OAuthServices:
                  login_account: str,
                  role_name: str,
                  token: str):
-        if token != '':
+        if token:
             self.token = token
         else:
             self.token = zign.api.get_token('sevenseconds', ['uid'])
@@ -239,7 +239,7 @@ def get_sessions(account_names: list,
                 token_managed_id_key=cfg.get('token_managed_id_key'),
                 login_account=options.get('login_account', None),
                 role_name=saml_role,
-                token=options.get('token', '')
+                token=options.get('token')
             )
         if batch.get(aws_credentials_service_url) is None:
             batch[aws_credentials_service_url] = {}


### PR DESCRIPTION
sevenseconds dies without any error message without `--token $(ztoken)`

raised error was `jwt.exceptions.DecodeError: Invalid token type. Token must be a <class 'bytes'>`