### PR TITLE
add kms key creation to the flow

### DIFF
--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -87,7 +87,7 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
     dns_domain = configure_dns(account)
     configure_iam(account, dns_domain)
     configure_s3_buckets(account)
-    create_deployment_key(account)
+    configure_kms_keys(account)
     configure_ses(account, dns_domain)
 
     regions = account.config['regions']

--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -87,7 +87,6 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
     dns_domain = configure_dns(account)
     configure_iam(account, dns_domain)
     configure_s3_buckets(account)
-    configure_kms_keys(account)
     configure_ses(account, dns_domain)
 
     regions = account.config['regions']
@@ -106,6 +105,7 @@ def configure_account_region(account: object, region: str, trusted_addresses: se
     sevenseconds.helper.THREADDATA.name = '{}|{}'.format(account.name, region)
     configure_log_group(account.session, region)
     configure_acm(account, region)
+    configure_kms_keys(account, region)
     vpc = configure_vpc(account, region)
     configure_bastion_host(account, vpc, region)
     configure_elasticache(account.session, region, vpc)

--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -15,7 +15,7 @@ from .acm import configure_acm
 from .ses import configure_ses
 from .iam import configure_iam
 from .s3 import configure_s3_buckets
-from .kms import create_deployment_key
+from .kms import configure_kms_keys
 from .cloudwatch import configure_log_group
 from .vpc import configure_vpc, if_vpc_empty, cleanup_vpc, delete_nat_host
 from .bastion import configure_bastion_host, delete_bastion_host

--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -15,6 +15,7 @@ from .acm import configure_acm
 from .ses import configure_ses
 from .iam import configure_iam
 from .s3 import configure_s3_buckets
+from .kms import create_deployment_key
 from .cloudwatch import configure_log_group
 from .vpc import configure_vpc, if_vpc_empty, cleanup_vpc, delete_nat_host
 from .bastion import configure_bastion_host, delete_bastion_host
@@ -86,6 +87,7 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
     dns_domain = configure_dns(account)
     configure_iam(account, dns_domain)
     configure_s3_buckets(account)
+    create_deployment_key(account)
     configure_ses(account, dns_domain)
 
     regions = account.config['regions']

--- a/sevenseconds/config/kms.py
+++ b/sevenseconds/config/kms.py
@@ -1,0 +1,38 @@
+from ..helper import ActionOnExit
+
+def create_deployment_key(account: object):
+    key_config = account.config.get('kms')
+    kms_client = account.session.client('kms')
+    for key_alias in key_config:
+        with ActionOnExit('Searching for key "{}" AMI..'.format(key_alias)) as act:
+            key_tags = key_config[key_alias]['tags']
+            converted_tags = []
+            for tag in key_tags: 
+                for key in tag:
+                    converted_tags.append({'TagKey': key, 'TagValue': tag[key]})
+            # check if the key is present
+            exist_aliases = kms_client.list_aliases()
+            found = False
+            for alias in exist_aliases['Aliases']:
+                if alias['AliasName'] == key_alias:
+                    found=True
+                    act.ok('key already exists')
+            if not found:
+                create_response = kms_client.create_key(
+                    Description='key used by deployment pipeline for secret encryption/decryption',
+                    KeyUsage='ENCRYPT_DECRYPT',
+                    Origin='AWS_KMS',
+                    BypassPolicyLockoutSafetyCheck=False,
+                    Tags=converted_tags
+                )
+                if create_response['ResponseMetadata']['HTTPStatusCode'] != 200:
+                    act.error('failed to create a key {} response: {}'.format(key_alias, create_response))
+                    return
+                key_id = create_response['KeyMetadata']['KeyId']
+                alias_response = kms_client.create_alias(
+                    AliasName=key_alias,
+                    TargetKeyId=key_id
+                )
+                if alias_response['ResponseMetadata']['HTTPStatusCode'] != 200:
+                    act.error('failed to create a key {} with key_id {} response: {}'.format(key_alias, key_id, alias_response))
+                    return

--- a/sevenseconds/config/kms.py
+++ b/sevenseconds/config/kms.py
@@ -36,6 +36,6 @@ def configure_kms_keys(account: object):
                 )
                 if alias_response['ResponseMetadata']['HTTPStatusCode'] != 200:
                     act.error(
-                        'failed to create alias {} with key_id {} response: {}'.format(key_alias, key_id, alias_response)
+                        'failed to create alias {} with key {} res:{}'.format(key_alias, key_id, alias_response)
                     )
                     return

--- a/sevenseconds/config/kms.py
+++ b/sevenseconds/config/kms.py
@@ -1,5 +1,6 @@
 from ..helper import ActionOnExit
 
+
 def configure_kms_keys(account: object):
     key_config = account.config.get('kms')
     kms_client = account.session.client('kms')
@@ -7,7 +8,7 @@ def configure_kms_keys(account: object):
         with ActionOnExit('Searching for key "{}"..'.format(key_alias)) as act:
             key_tags = key_config[key_alias]['tags']
             converted_tags = []
-            for tag in key_tags: 
+            for tag in key_tags:
                 for key in tag:
                     converted_tags.append({'TagKey': key, 'TagValue': tag[key]})
             # check if the key is present
@@ -15,7 +16,7 @@ def configure_kms_keys(account: object):
             found = False
             for alias in exist_aliases['Aliases']:
                 if alias['AliasName'] == key_alias:
-                    found=True
+                    found = True
                     act.ok('key already exists')
             if not found:
                 create_response = kms_client.create_key(
@@ -34,5 +35,7 @@ def configure_kms_keys(account: object):
                     TargetKeyId=key_id
                 )
                 if alias_response['ResponseMetadata']['HTTPStatusCode'] != 200:
-                    act.error('failed to create a key {} with key_id {} response: {}'.format(key_alias, key_id, alias_response))
+                    act.error(
+                        'failed to create alias {} with key_id {} response: {}'.format(key_alias, key_id, alias_response)
+                    )
                     return

--- a/sevenseconds/config/kms.py
+++ b/sevenseconds/config/kms.py
@@ -1,6 +1,6 @@
 from ..helper import ActionOnExit
 
-def create_deployment_key(account: object):
+def configure_kms_keys(account: object):
     key_config = account.config.get('kms')
     kms_client = account.session.client('kms')
     for key_alias in key_config:

--- a/sevenseconds/config/kms.py
+++ b/sevenseconds/config/kms.py
@@ -2,9 +2,9 @@ from ..helper import ActionOnExit
 import json
 
 
-def configure_kms_keys(account: object):
-    keys_config = account.config.get('kms')
-    kms_client = account.session.client('kms')
+def configure_kms_keys(account: object, region):
+    keys_config = account.config.get('kms', {})
+    kms_client = account.session.client('kms', region)
     for key_alias in keys_config:
         key_config = keys_config[key_alias]
         key = json.loads(json.dumps(key_config).replace('{account_id}', account.id))

--- a/sevenseconds/config/kms.py
+++ b/sevenseconds/config/kms.py
@@ -8,7 +8,7 @@ def configure_kms_keys(account: object):
     for key_alias in keys_config:
         key_config = keys_config[key_alias]
         key = json.loads(json.dumps(key_config)
-                                .replace('{account_id}', account.id))
+            .replace('{account_id}', account.id))
         with ActionOnExit('Searching for key "{}"..'.format(key_alias)) as act:
             exist_aliases = kms_client.list_aliases()
             found = False
@@ -20,14 +20,14 @@ def configure_kms_keys(account: object):
                         KeyId=alias['TargetKeyId'],
                         PolicyName='default',
                         Policy=json.dumps(key['KeyPolicy']),
-                        BypassPolicyLockoutSafetyCheck=False                        
+                        BypassPolicyLockoutSafetyCheck=False
                     )
                     if put_key_response['ResponseMetadata']['HTTPStatusCode'] != 200:
                         act.error(
                             'failed to update key policy for {} response: {}'
-                                .format(key_alias, create_response)
+                            .format(key_alias, put_key_response)
                         )
-                        break  
+                        break
                     act.ok("updated key policy for {}".format(key_alias))
                     break
             if not found:
@@ -50,6 +50,6 @@ def configure_kms_keys(account: object):
                 if alias_response['ResponseMetadata']['HTTPStatusCode'] != 200:
                     act.error(
                         'failed to create alias {} with key {} res:{}'
-                            .format(key_alias, key_id, alias_response)
+                        .format(key_alias, key_id, alias_response)
                     )
                     continue

--- a/sevenseconds/config/kms.py
+++ b/sevenseconds/config/kms.py
@@ -7,8 +7,7 @@ def configure_kms_keys(account: object):
     kms_client = account.session.client('kms')
     for key_alias in keys_config:
         key_config = keys_config[key_alias]
-        key = json.loads(json.dumps(key_config)
-            .replace('{account_id}', account.id))
+        key = json.loads(json.dumps(key_config).replace('{account_id}', account.id))
         with ActionOnExit('Searching for key "{}"..'.format(key_alias)) as act:
             exist_aliases = kms_client.list_aliases()
             found = False

--- a/sevenseconds/config/kms.py
+++ b/sevenseconds/config/kms.py
@@ -4,7 +4,7 @@ def configure_kms_keys(account: object):
     key_config = account.config.get('kms')
     kms_client = account.session.client('kms')
     for key_alias in key_config:
-        with ActionOnExit('Searching for key "{}" AMI..'.format(key_alias)) as act:
+        with ActionOnExit('Searching for key "{}"..'.format(key_alias)) as act:
             key_tags = key_config[key_alias]['tags']
             converted_tags = []
             for tag in key_tags: 


### PR DESCRIPTION
This PR adds kms key for each account if specified in the configuration. It also allows to update the policy when key_alias already there. See our configuration for the pattern we will use:

```
  kms:
    my_key_alias:
      Description: "my-description"
      Enabled: true
      EnableKeyRotation: false
      KeyUsage: "ENCRYPT_DECRYPT"
      KeyPolicy:
        Version: "2012-10-17"
        Id: "key-policy"
        Statement:
          - Sid: "Allow access for Key Administrators"
            Effect: "Allow"
            Resource: "*"
            Principal:
              AWS: "arn:aws:iam::{account_id}:root"
            Action:
              - "kms:ReEncrypt*"
```

/cc @tuxlife @szuecs 