### PR TITLE
Support multiple base AMI channels

### DIFF
--- a/examples/example-full-configuration.yaml
+++ b/examples/example-full-configuration.yaml
@@ -23,7 +23,10 @@ global:
   saml_admin_login_role: "Shibboleth-Administrator"
   # base Taupage AMI to search for
   base_ami:
-    name: "Taupage-AMI-*"
+    default_channel: "Taupage-AMI-*"
+    channels:
+      - "TaupageStaging-AMI-*"
+      - "TaupageDev-AMI-*"
     is_public: false
     # account_id of the AMI creator
     onwer_id: 123456789123

--- a/examples/example-minimal-configuration.yaml
+++ b/examples/example-minimal-configuration.yaml
@@ -13,7 +13,7 @@ global:
   domain: "{account_name}.example.org"
   # base Taupage AMI to search for
   base_ami:
-    name: "Taupage-AMI-*"
+    default_channel: "Taupage-AMI-*"
     is_public: false
     # account_id of the AMI creator
     onwer_id: 123456789123

--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -80,11 +80,12 @@ def configure(file, account_name_pattern, **options):
             file,
             account_name_pattern,
             options)
+        sessions = list(sessions.values())
     except Exception as e:
         fatal_error("Can't get sessions. Error: {}".format(e))
 
     # Get NAT/ODD Addresses. Need the first Session to get all AZ for the Regions
-    trusted_addresses = get_trusted_addresses(list(sessions.values())[0].admin_session, config)
+    trusted_addresses = get_trusted_addresses(sessions[0].admin_session, config)
     run_successfully = start_configuration(sessions, trusted_addresses, options)
     if not run_successfully:
         sys.exit(1)

--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -80,13 +80,13 @@ def configure(file, account_name_pattern, **options):
             file,
             account_name_pattern,
             options)
-        sessions = list(sessions.values())
+        session_list = list(sessions.values())
     except Exception as e:
         fatal_error("Can't get sessions. Error: {}".format(e))
 
     # Get NAT/ODD Addresses. Need the first Session to get all AZ for the Regions
-    trusted_addresses = get_trusted_addresses(sessions[0].admin_session, config)
-    run_successfully = start_configuration(sessions, trusted_addresses, options)
+    trusted_addresses = get_trusted_addresses(session_list[0].admin_session, config)
+    run_successfully = start_configuration(session_list, trusted_addresses, options)
     if not run_successfully:
         sys.exit(1)
 

--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -12,6 +12,7 @@ from .policysimulator import check_policy_simulator
 from .cloudtrail import configure_cloudtrail_all_regions
 from .route53 import configure_dns
 from .acm import configure_acm
+from .ami import latest_base_images, configure_base_images
 from .iam import configure_iam
 from .s3 import configure_s3_buckets
 from .kms import configure_kms_keys
@@ -39,20 +40,50 @@ AccountData = namedtuple(
         'auth'              # OAuthServices Object (exp. for Account List and AWS Credentials Service)
     ))
 
+SharedData = namedtuple(
+    'SharedData',
+    (
+        'base_images',      # {region -> {channel -> ami_id}}
+        'trusted_addresses'
+    ))
+
 
 def start_configuration(sessions: list, trusted_addresses: set, options: dict):
     info('Start Pool processing...')
+
+    # TODO move trusted_addresses to prepare_shared_data
+    shared_data = prepare_shared_data(sessions, trusted_addresses)
+
     with Pool(processes=options.get('max_procs', os.cpu_count())) as pool:
-        run_successfully = pool.starmap(configure_account_except, zip(sessions.values(), repeat(trusted_addresses)))
+        run_successfully = pool.starmap(configure_account_except, zip(sessions, repeat(shared_data)))
     info('Pool processing done...')
     if all(run_successfully):
         return True
     return False
 
 
-def configure_account_except(session_data: AccountData, trusted_addresses: set):
+def prepare_shared_data(sessions: list, trusted_addresses: set):
+    """Returns the latest AMI IDs for each configured channel for all used regions"""
+    ami_session = boto3.session.Session(**sessions[0].ami_session)
+    ami_config = sessions[0].config['base_ami']
+    default_channel = ami_config['default_channel']
+
+    images = {}
+    for session in sessions:
+        if session.config['base_ami'] != ami_config:
+            raise Exception("base_ami config overrides are unsupported")
+
+        for region in session.config['regions']:
+            if region not in images:
+                images[region] = latest_base_images(ami_session, region, ami_config)
+                if default_channel not in images[region]:
+                    raise Exception("Unable to find default base AMI ({}) for region {}".format(default_channel, region))
+    return SharedData(images, trusted_addresses)
+
+
+def configure_account_except(session_data: AccountData, shared_data: SharedData):
     try:
-        configure_account(session_data, trusted_addresses)
+        configure_account(session_data, shared_data)
         return True
     except Exception as e:
         error(traceback.format_exc())
@@ -60,7 +91,7 @@ def configure_account_except(session_data: AccountData, trusted_addresses: set):
         return False
 
 
-def configure_account(session_data: AccountData, trusted_addresses: set):
+def configure_account(session_data: AccountData, shared_data: SharedData):
     start_time = time.time()
     sevenseconds.helper.THREADDATA.name = session_data.name
     session = {}
@@ -93,23 +124,28 @@ def configure_account(session_data: AccountData, trusted_addresses: set):
     if len(regions) > 0:
         with ThreadPoolExecutor(max_workers=len(regions)) as executor:
             for region in regions:
-                futures.append(executor.submit(configure_account_region, account, region, trusted_addresses))
+                futures.append(executor.submit(configure_account_region, account, region, shared_data))
     for future in futures:
         # will raise an exception if the jobs failed
         future.result()
     ok('Done with {} / {} after {}'.format(account.id, account.name, timedelta(seconds=time.time() - start_time)))
 
 
-def configure_account_region(account: object, region: str, trusted_addresses: set):
+def configure_account_region(account: object, region: str, shared_data: SharedData):
     sevenseconds.helper.THREADDATA.name = '{}|{}'.format(account.name, region)
+
+    base_images = shared_data.base_images.get(region, {})
+    default_base_ami = base_images[account.config['base_ami']['default_channel']]
+
     configure_log_group(account.session, region)
     configure_acm(account, region)
     configure_kms_keys(account, region)
-    vpc = configure_vpc(account, region)
-    configure_bastion_host(account, vpc, region)
+    configure_base_images(account, region, base_images)
+    vpc = configure_vpc(account, region, default_base_ami)
+    configure_bastion_host(account, vpc, region, default_base_ami)
     configure_elasticache(account.session, region, vpc)
     configure_rds(account.session, region, vpc)
-    configure_security_groups(account, region, trusted_addresses, vpc)
+    configure_security_groups(account, region, shared_data.trusted_addresses, vpc)
 
 
 def start_cleanup(region: str, sessions: list, options: dict):

--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -77,7 +77,7 @@ def prepare_shared_data(sessions: list, trusted_addresses: set):
             if region not in images:
                 images[region] = latest_base_images(ami_session, region, ami_config)
                 if default_channel not in images[region]:
-                    raise Exception("Unable to find default base AMI ({}) for region {}".format(default_channel, region))
+                    raise Exception("Unable to find default base AMI {} for region {}".format(default_channel, region))
     return SharedData(images, trusted_addresses)
 
 

--- a/sevenseconds/config/ami.py
+++ b/sevenseconds/config/ami.py
@@ -1,11 +1,10 @@
-import functools
-from ..helper import info, ActionOnExit
+from ..helper import ActionOnExit
 
 
 def latest_ami(session: object, region: str, config: dict, channel: str):
     ec2 = session.resource('ec2', region)
 
-    with ActionOnExit('Searching for latest "{}" AMI..'.format(channel)) as act:
+    with ActionOnExit('Searching for latest "{}" AMI..'.format(channel)):
         filters = {"name": channel,
                    "is-public": "true" if config['is_public'] else "false",
                    "state": "available",
@@ -36,7 +35,7 @@ def configure_base_images(account: object, region: str, latest_images: dict):
 
     image_ids = list(filter(None, latest_images.values()))
 
-    with ActionOnExit('Checking that all AMIs ({}) are available...'.format(', '.join(image_ids))) as act:
+    with ActionOnExit('Checking that all AMIs ({}) are available...'.format(', '.join(image_ids))):
         available_images = set(image.id for image in ec2.images.filter(ImageIds=image_ids))
         pending_image_ids = [image for image in image_ids if image not in available_images]
 

--- a/sevenseconds/config/ami.py
+++ b/sevenseconds/config/ami.py
@@ -1,66 +1,53 @@
+import functools
 from ..helper import info, ActionOnExit
 
 
-def get_base_ami_id(account: object, region: str):
-    images = search_base_ami_ids(account.session, account.config, region)
-    if not images:
-        permit_base_image(account, region)
-        images = search_base_ami_ids(account.session, account.config, region)
-        if not images:
-            raise Exception('No AMI found')
-    most_recent_image = images[0]
-    info('Most recent AMI is "{}" ({})'.format(most_recent_image.name, most_recent_image.id))
-    return most_recent_image.id
-
-
-def search_base_ami_ids(session: object, config: dict, region: str):
+def latest_ami(session: object, region: str, config: dict, channel: str):
     ec2 = session.resource('ec2', region)
-    base_ami = config['base_ami']
-    name = base_ami['name']
-    with ActionOnExit('Searching for latest "{}" AMI..'.format(name)) as act:
-        filters = get_filter(**base_ami)
-        images = sorted(ec2.images.filter(Filters=filters), key=lambda x: x.creation_date, reverse=True)
-        if not images:
-            act.error('no AMI found for Filter: {}'.format(filters))
-        return images
 
+    with ActionOnExit('Searching for latest "{}" AMI..'.format(channel)) as act:
+        filters = {"name": channel,
+                   "is-public": "true" if config['is_public'] else "false",
+                   "state": "available",
+                   "root-device-type": "ebs",
+                   "owner-id": config.get('owner_id')}
 
-def get_filter(name, is_public, owner_id, **kwargs):
-    filters = [
-        {'Name': 'name',
-         'Values': [name]},
-        {'Name': 'is-public',
-         'Values': [str(is_public).lower()]},
-        {'Name': 'state',
-         'Values': ['available']},
-        {'Name': 'root-device-type',
-         'Values': ['ebs']}
-        ]
-    if owner_id:
-        filters.append({'Name': 'owner-id',
-                        'Values': [str(owner_id)]})
-    return filters
-
-
-def permit_base_image(account: object, region: str):
-    ami_ec2 = account.ami_session.resource('ec2', region)
-    base_ami = account.config['base_ami']
-    name = base_ami['name']
-    with ActionOnExit('Permit "{}" for "{}/{}"..'.format(name, account.id, account.alias)) as act:
-        if ami_ec2:
-            images = []
-            for image in search_base_ami_ids(account.ami_session, account.config, region):
-                if len(image.describe_attribute(Attribute='launchPermission')['LaunchPermissions']) < 10:
-                    continue
-                if image.modify_attribute(Attribute='launchPermission', OperationType='add', UserIds=[account.id]):
-                    images.append(image.id)
-                    act.progress()
-                else:
-                    act.warning('Error on Image {}/{}'.format(image.id, image.name))
+        images = sorted(ec2.images.filter(Filters=ami_filter(filters)), key=lambda x: x.creation_date, reverse=True)
+        if images:
+            return images[0].id
         else:
-            act.error('No connection to "base_ami_account"')
-    if images:
-        with ActionOnExit('Waiting of AWS-Sync'):
-            ec2c = account.session.client('ec2', region)
-            waiter = ec2c.get_waiter('image_available')
-            waiter.wait(Filters=get_filter(**base_ami))
+            return None
+
+
+def ami_filter(predicates):
+    return [{"Name": k, "Values": [str(v)]} for k, v in predicates.items() if v]
+
+
+def latest_base_images(ami_session: object, region: str, config: dict):
+    channels = set(config.get('channels', []))
+    channels.add(config['default_channel'])
+
+    return {channel: latest_ami(ami_session, region, config, channel) for channel in channels}
+
+
+def configure_base_images(account: object, region: str, latest_images: dict):
+    ec2 = account.session.resource('ec2', region)
+    ami_ec2 = account.ami_session.resource('ec2', region)
+
+    image_ids = list(filter(None, latest_images.values()))
+
+    with ActionOnExit('Checking that all AMIs ({}) are available...'.format(', '.join(image_ids))) as act:
+        available_images = set(image.id for image in ec2.images.filter(ImageIds=image_ids))
+        pending_image_ids = [image for image in image_ids if image not in available_images]
+
+    if pending_image_ids:
+        # Allow access from the AMI account
+        for image in ami_ec2.images.filter(ImageIds=pending_image_ids):
+            with ActionOnExit('Permit {} for "{}/{}"..'.format(image.id, account.id, account.alias)) as act:
+                image.modify_attribute(Attribute='launchPermission', OperationType='add', UserIds=[account.id])
+
+        # Wait until all images are available
+        with ActionOnExit('Waiting of AWS-Sync') as act:
+            for image in ec2.images.filter(ImageIds=pending_image_ids):
+                image.wait_until_exists()
+                act.progress()

--- a/sevenseconds/config/bastion.py
+++ b/sevenseconds/config/bastion.py
@@ -10,11 +10,10 @@ import json
 from copy import deepcopy
 from ..helper import info, warning, error, ActionOnExit, substitute_template_vars
 from ..helper.aws import filter_subnets, associate_address, get_tag
-from .ami import get_base_ami_id
 from .route53 import configure_dns_record, delete_dns_record
 
 
-def configure_bastion_host(account: object, vpc: object, region: str):
+def configure_bastion_host(account: object, vpc: object, region: str, base_ami_id: str):
     ec2 = account.session.resource('ec2', region)
     cf = account.session.resource('cloudformation', region)
     cfc = account.session.client('cloudformation', region)
@@ -38,7 +37,6 @@ def configure_bastion_host(account: object, vpc: object, region: str):
                                        'vpc_net': str(vpc.cidr_block),
                                        'version': bastion_version})
     user_data = '#taupage-ami-config\n{}'.format(yaml.safe_dump(config)).encode('utf-8')
-    ami_id = get_base_ami_id(account, region)
 
     # Search all existing hosts (Instances and Cloudformation)
     instance_filter = [
@@ -55,8 +53,8 @@ def configure_bastion_host(account: object, vpc: object, region: str):
         else:
             # Verify Running Version (Userdate, FS Parameter)
             inst_user_data = base64.b64decode(instance.describe_attribute(Attribute='userData')['UserData']['Value'])
-            if instance.image_id != ami_id:
-                error('{} use {} instand of {}.'.format(instance.id, instance.image_id, ami_id))
+            if instance.image_id != base_ami_id:
+                error('{} use {} instand of {}.'.format(instance.id, instance.image_id, base_ami_id))
                 if re_deploy or account.options.get('update_odd_host'):
                     error(' ==> Make re-deploy')
                     re_deploy = True
@@ -101,8 +99,8 @@ def configure_bastion_host(account: object, vpc: object, region: str):
                 oddstack = cf.Stack(get_tag(instance.tags, 'aws:cloudformation:stack-name'))
 
                 used_ami_id = get_tag(oddstack.parameters, 'TaupageId', prefix='Parameter')
-                if used_ami_id != ami_id:
-                    error('{} use {} instand of {}.'.format(oddstack.name, used_ami_id, ami_id))
+                if used_ami_id != base_ami_id:
+                    error('{} use {} instand of {}.'.format(oddstack.name, used_ami_id, base_ami_id))
                     if re_deploy or account.options.get('update_odd_host'):
                         error(' ==> prepare change set')
                         update_needed = True
@@ -113,7 +111,7 @@ def configure_bastion_host(account: object, vpc: object, region: str):
                         error(' ==> prepare change set')
                         update_needed = True
                 if update_needed or re_deploy:
-                    update_cf_bastion_host(account, vpc, region, oddstack, ami_id, bastion_version)
+                    update_cf_bastion_host(account, vpc, region, oddstack, base_ami_id, bastion_version)
                 if not legacy_instances:
                     info('check old odd security groups')
                     cleanup_old_security_group(account, region, oddstack, vpc)
@@ -123,7 +121,7 @@ def configure_bastion_host(account: object, vpc: object, region: str):
             stack = cf.Stack('Odd')
             info('Stack Status: {}'.format(stack.stack_status))
         except Exception:
-            create_cf_bastion_host(account, vpc, region, ami_id, bastion_version)
+            create_cf_bastion_host(account, vpc, region, base_ami_id, bastion_version)
         if stack.stack_status in ('UPDATE_IN_PROGRESS', 'CREATE_IN_PROGRESS'):
             if stack.stack_status.startswith('UPDATE_'):
                 waiter = cfc.get_waiter('stack_update_complete')
@@ -143,7 +141,7 @@ def configure_bastion_host(account: object, vpc: object, region: str):
         if (not wait_for_ssh_port(instance.public_ip_address, 60) and
                 datetime.timedelta(minutes=15) < datetime.datetime.now(launch_time.tzinfo) - launch_time):
             error('Bastion Host does not response. Force Update for Bastionhost Stack')
-            update_cf_bastion_host(account, vpc, region, stack, ami_id, bastion_version)
+            update_cf_bastion_host(account, vpc, region, stack, base_ami_id, bastion_version)
 
 
 def cleanup_old_security_group(account: object, region: str, oddstack: object, vpc: object):
@@ -333,179 +331,6 @@ def update_cf_bastion_host(account: object, vpc: object, region: str, stack: obj
         except botocore.exceptions.WaiterError as e:
             act.error('Stack creation failed: {}'.format(e))
             return
-
-
-def configure_bastion_host_deprecated(account: object, vpc: object, region: str):
-    ec2c = account.session.client('ec2', region)
-    cwc = account.session.client('cloudwatch', region)
-    # account_name: str, dns_domain: str, ec2_conn, subnets: list, cfg: dict, vpc_net: IPNetwork
-    try:
-        subnet = list(filter_subnets(vpc, 'dmz'))[0]
-    except Exception:
-        warning('No DMZ subnet found')
-        return
-
-    az_name = subnet.availability_zone
-    # FIXME Add SG Check/Update for all Ho
-    sg_name = 'Odd (SSH Bastion Host)'
-    sg = [x for x in vpc.security_groups.all() if x.group_name == sg_name]
-    if not sg:
-        sg = vpc.create_security_group(GroupName=sg_name,
-                                       Description='Allow SSH access to the bastion host')
-        # We are to fast for AWS (InvalidGroup.NotFound)
-        time.sleep(2)
-        sg.create_tags(Tags=[{'Key': 'Name', 'Value': sg_name}])
-        sg.authorize_ingress(IpPermissions=[
-            {
-                'IpProtocol': 'tcp',
-                'FromPort': port,
-                'ToPort': port,
-                'IpRanges': [{'CidrIp': '0.0.0.0/0'}]
-            } for port in (22, 2222)])
-    else:
-        sg = sg[0]
-
-    if account.config['bastion'].get('version_url'):
-        with ActionOnExit('Get last Tag for Bastion Image...') as act:
-            r = requests.get(account.config['bastion'].get('version_url'))
-            if r.status_code != 200:
-                act.error('Error code: {}'.format(r.status_code))
-                act.error('Error msg: {}'.format(r.text))
-                return
-            tags = sorted(r.json(), key=lambda x: x['created'], reverse=True)
-            config = substitute_template_vars(account.config['bastion'].get('ami_config'),
-                                              {'account_name': account.name,
-                                               'vpc_net': str(vpc.cidr_block),
-                                               'version': tags[0]['name']})
-    else:
-        config = substitute_template_vars(account.config['bastion'].get('ami_config'),
-                                          {'account_name': account.name, 'vpc_net': str(vpc.cidr_block)})
-    user_data = '#taupage-ami-config\n{}'.format(yaml.safe_dump(config)).encode('utf-8')
-    ami_id = get_base_ami_id(account, region)
-
-    filters = [
-        {'Name': 'tag:Name',
-         'Values': [sg_name]},
-        {'Name': 'instance-state-name',
-         'Values': ['running', 'pending']},
-    ]
-    instances = list(vpc.instances.filter(Filters=filters))
-    re_deploy = account.config['bastion'].get('re_deploy', account.options.get('redeploy_odd_host'))
-
-    for instance in instances:
-        inst_user_data = base64.b64decode(instance.describe_attribute(Attribute='userData')['UserData']['Value'])
-        if instance.image_id != ami_id:
-            error('{} use {} instand of {}.'.format(instance.id, instance.image_id, ami_id))
-            if not re_deploy and account.options.get('update_odd_host'):
-                error(' ==> Make re-deploy')
-                re_deploy = True
-        if inst_user_data != user_data:
-            original = inst_user_data.decode('utf-8')
-            new = user_data.decode('utf-8')
-            diff = difflib.ndiff(original.splitlines(1), new.splitlines(1))
-            error('{} use a different UserData\n{}'.format(instance.id, ''.join(diff)))
-            if not re_deploy and account.options.get('update_odd_host'):
-                error(' ==> Make re-deploy')
-                re_deploy = True
-
-    if instances and re_deploy:
-        for instance in instances:
-            drop_bastionhost(instance)
-        instances = None
-
-    if instances:
-        instance = instances[0]
-        ip = instance.public_ip_address
-    else:
-        with ActionOnExit('Launching SSH Bastion instance in {az_name}..', az_name=az_name):
-            instance = subnet.create_instances(ImageId=ami_id,
-                                               InstanceType=account.config['bastion'].get('instance_type', 't2.micro'),
-                                               SecurityGroupIds=[sg.id],
-                                               UserData=user_data,
-                                               MinCount=1,
-                                               MaxCount=1,
-                                               DisableApiTermination=True,
-                                               Monitoring={'Enabled': True})[0]
-
-            waiter = ec2c.get_waiter('instance_running')
-            waiter.wait(InstanceIds=[instance.id])
-            instance.create_tags(Tags=[{'Key': 'Name', 'Value': sg_name}])
-            ip = None
-            # FIXME activate Autorecovery !!
-            cwc.put_metric_alarm(AlarmName='odd-host-{}-auto-recover'.format(instance.id),
-                                 AlarmActions=['arn:aws:automate:{}:ec2:recover'.format(region)],
-                                 MetricName='StatusCheckFailed',
-                                 Namespace='AWS/EC2',
-                                 Statistic='Minimum',
-                                 Dimensions=[{
-                                     'Name': 'InstanceId',
-                                     'Value': instance.id
-                                 }],
-                                 Period=60,  # 1 minute
-                                 EvaluationPeriods=2,
-                                 Threshold=0,
-                                 ComparisonOperator='GreaterThanThreshold')
-
-    if ip is None:
-        with ActionOnExit('Associating Elastic IP to {}..'.format(instance.id)):
-            ip = associate_address(ec2c, instance.id)
-    info('SSH Bastion instance is running with public IP {}'.format(ip))
-
-    try:
-        sg.revoke_egress(IpPermissions=[
-            {
-                'IpProtocol': '-1',
-                'FromPort': -1,
-                'ToPort': -1,
-                'IpRanges': [
-                    {
-                        'CidrIp': '0.0.0.0/0'
-                    }
-                ]
-            }])
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'InvalidPermission.NotFound':
-            pass
-        else:
-            raise
-    rules = [
-        # allow ALL connections to our internal EC2 instances
-        ('tcp', 0, 65535, vpc.cidr_block),
-        # allow HTTPS to the internet (actually only needed for SSH access service)
-        ('tcp', 443, 443, '0.0.0.0/0'),
-        # allow PostgreSQL to the internet (actually only needed for DBaaS)
-        ('tcp', 5432, 5432, '0.0.0.0/0'),
-        # allow pings
-        ('icmp', -1, -1, '0.0.0.0/0'),
-        # allow DNS
-        ('udp', 53, 53, '0.0.0.0/0'),
-        ('tcp', 53, 53, '0.0.0.0/0'),
-    ]
-    for proto, from_port, to_port, cidr in rules:
-        try:
-            sg.authorize_egress(IpPermissions=[
-                {
-                    'IpProtocol': str(proto),
-                    'FromPort': from_port,
-                    'ToPort': to_port,
-                    'IpRanges': [
-                        {
-                            'CidrIp': str(cidr)
-                        }
-                    ]
-                }])
-        except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] != 'InvalidPermission.Duplicate':
-                raise
-
-    configure_dns_record(account, 'odd-{}'.format(region), ip)
-
-    launch_time = instance.launch_time
-    if (not wait_for_ssh_port(ip, 60) and
-            datetime.timedelta(minutes=15) < datetime.datetime.now(launch_time.tzinfo) - launch_time):
-        error('Bastion Host does not response. Drop Bastionhost and create new one')
-        drop_bastionhost(instance)
-        configure_bastion_host(account, vpc, region)
 
 
 def drop_bastionhost(instance):


### PR DESCRIPTION
 - config.base_ami: rename name to default_channel, add an optional channels list
 - only the latest base AMI is configured for each region and channel
 - list of latest base AMIs is prepared once and then reused across all accounts to avoid rate limit issues. per-account overrides are thus unsupported, but I don't think they make a lot of sense
 - dropped an unused configure_bastion_host_deprecated function