### PR TITLE
Ignore certificates in PENDING_AUTO_RENEWAL

### DIFF
--- a/sevenseconds/config/acm.py
+++ b/sevenseconds/config/acm.py
@@ -63,6 +63,11 @@ def renew_certificate(acm, cert):
 
 
 def resend_validation_email(acm, cert):
+    renewal_status = cert.get('RenewalSummary', {}).get('RenewalStatus')
+    if renewal_status != 'PENDING_VALIDATION':
+        info('Certificate {} in {}, not resending validation email'.format(cert['CertificateArn'], renewal_status))
+        return
+
     with ActionOnExit('Certificate {} still Pending. Resend Validation...'
                       .format(cert['CertificateArn'])):
         for d in cert["DomainValidationOptions"]:

--- a/sevenseconds/config/acm.py
+++ b/sevenseconds/config/acm.py
@@ -58,7 +58,7 @@ def renew_certificate(acm, cert):
                     Domain=d["DomainName"],
                     ValidationDomain=d["ValidationDomain"]
                 )
-            except Exception as e:
+            except Exception:
                 act_renew.error('found existing config')
 
 

--- a/sevenseconds/config/route53.py
+++ b/sevenseconds/config/route53.py
@@ -40,7 +40,7 @@ def configure_dns(account: object):
     return dns_domain
 
 
-def configure_dns_delegation(admin_session: object, domain: str, nameservers: list, action: str='UPSERT'):
+def configure_dns_delegation(admin_session: object, domain: str, nameservers: list, action: str = 'UPSERT'):
     route53 = admin_session.client('route53')
     zone_id = find_zoneid(domain, route53)
     if zone_id:

--- a/sevenseconds/helper/aws.py
+++ b/sevenseconds/helper/aws.py
@@ -65,7 +65,7 @@ def get_tag(tags: list, key: str, default=None, prefix=''):
     return default
 
 
-def associate_address(ec2c: object, instance_id: str=None):
+def associate_address(ec2c: object, instance_id: str = None):
     addr = None
     for vpc_addresse in ec2c.describe_addresses()['Addresses']:
         if (vpc_addresse.get('AssociationId') is None and


### PR DESCRIPTION
ACM doesn't allow sending validation emails for certificates in `PENDING_AUTO_RENEWAL`, only `PENDING_VALIDATION`. Ignore those instead of failing.