### PR TITLE
Only attempt to drop cloudtrail data from relevant regions

### DIFF
--- a/sevenseconds/config/cloudtrail.py
+++ b/sevenseconds/config/cloudtrail.py
@@ -28,8 +28,10 @@ def drop_old_cloudtrails(account):
         regions.remove(home_region)
 
     futures = []
-    with ThreadPoolExecutor(max_workers=len(regions)) as executor:
-        for region in regions:
+    cloudtrail_regions = account.config.get('cloudtrail', {}).get('regions', [])
+    enabled_regions = list(set(regions).intersection(set(cloudtrail_regions)))
+    with ThreadPoolExecutor(max_workers=len(enabled_regions)) as executor:
+        for region in enabled_regions:
             futures.append(executor.submit(drop_old_cloudtrails_worker, account, region, account.dry_run))
     for future in futures:
         # will raise an exception if the jobs failed


### PR DESCRIPTION
Instead of checking all regions with cloudtrail limit it to regions that we actually have used. This fixes an issue where we tried to check the region `ap-east-1` which is disabled by default and therefore makes sevenseconds fail. This is the first region which is disabled by default in AWS, why we didn't see this issue before.

Depends on internal configuration PR.