### PR TITLE
Allow opting out of DNS management

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -11,10 +11,10 @@ from .helper import error, info, fatal_error
 from .helper.auth import get_sessions
 from .helper.network import get_trusted_addresses
 from .helper.regioninfo import get_regions
-from .config import start_configuration, start_cleanup
+from .config.configure import start_configuration, start_cleanup
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-SUPPORTED_CONFIG_VERSION = 1
+SUPPORTED_CONFIG_VERSION = 2
 
 
 def print_version(ctx, param, value):

--- a/sevenseconds/config/__init__.py
+++ b/sevenseconds/config/__init__.py
@@ -1,206 +1,33 @@
-import boto3
-import os
-from itertools import repeat
-from multiprocessing import Pool
-import traceback
 from collections import namedtuple
-import time
-from datetime import timedelta
-from ..helper import error, info, ok
-from ..helper.aws import get_account_id, get_account_alias, set_account_alias
-from .policysimulator import check_policy_simulator
-from .cloudtrail import configure_cloudtrail_all_regions
-from .route53 import configure_dns
-from .acm import configure_acm
-from .ami import latest_base_images, configure_base_images
-from .ec2 import configure_ebs_encryption
-from .iam import configure_iam
-from .s3 import configure_s3_buckets
-from .kms import configure_kms_keys
-from .cloudwatch import configure_log_group
-from .vpc import configure_vpc, if_vpc_empty, cleanup_vpc, delete_nat_host
-from .bastion import configure_bastion_host, delete_bastion_host
-from .elasticache import configure_elasticache
-from .rds import configure_rds
-from .securitygroup import configure_security_groups
-from concurrent.futures import ThreadPoolExecutor
-import sevenseconds.helper
+from typing import NamedTuple, Optional
 
-AccountData = namedtuple(
-    'AccountData',
-    (
-        'name',             # Short Name of this Account
-        'alias',            # Full AWS Account Alias Name (prefix + name)
-        'id',               # AWS Account ID
-        'session',          # Boto3 Session for the current Account
-        'admin_session',    # Boto3 Session for the Admin Account (for DNS deligation)
-        'ami_session',      # Boto3 Session of the Taupage Owner Accounts (for EC2 AMI)
-        'config',           # Configuration of the current Account
-        'dry_run',          # dry-run boolean Flag
-        'options',          # Command Options dict
-        'auth'              # OAuthServices Object (exp. for Account List and AWS Credentials Service)
-    ))
+import boto3
+
+from ..helper.auth import OAuthServices
+
+
+class AccountData(NamedTuple):
+    name: str  # Short Name of this Account
+    alias: str  # Full AWS Account Alias Name (prefix + name)
+    id: str  # AWS Account ID
+    session: boto3.Session  # Boto3 Session for the current Account
+    admin_session: boto3.Session  # Boto3 Session for the Admin Account (for DNS deligation)
+    ami_session: boto3.Session  # Boto3 Session of the Taupage Owner Accounts (for EC2 AMI)
+    config: dict  # Configuration of the current Account
+    dry_run: bool  # dry-run boolean Flag
+    options: dict  # Command Options dict
+    auth: OAuthServices  # OAuthServices Object (exp. for Account List and AWS Credentials Service)
+
+    @property
+    def domain(self) -> Optional[str]:
+        if self.config['domain'] is None:
+            return None
+        return self.config['domain'].format(account_name=self.name)
+
 
 SharedData = namedtuple(
     'SharedData',
     (
-        'base_images',      # {region -> {channel -> ami_id}}
+        'base_images',  # {region -> {channel -> ami_id}}
         'trusted_addresses'
     ))
-
-
-def start_configuration(sessions: list, trusted_addresses: set, options: dict):
-    info('Start Pool processing...')
-
-    # TODO move trusted_addresses to prepare_shared_data
-    shared_data = prepare_shared_data(sessions, trusted_addresses)
-
-    with Pool(processes=options.get('max_procs', os.cpu_count())) as pool:
-        run_successfully = pool.starmap(configure_account_except, zip(sessions, repeat(shared_data)))
-    info('Pool processing done...')
-    if all(run_successfully):
-        return True
-    return False
-
-
-def prepare_shared_data(sessions: list, trusted_addresses: set):
-    """Returns the latest AMI IDs for each configured channel for all used regions"""
-    ami_session = boto3.session.Session(**sessions[0].ami_session)
-    ami_config = sessions[0].config['base_ami']
-    default_channel = ami_config['default_channel']
-
-    images = {}
-    for session in sessions:
-        if session.config['base_ami'] != ami_config:
-            raise Exception("base_ami config overrides are unsupported")
-
-        for region in session.config['regions']:
-            if region not in images:
-                images[region] = latest_base_images(ami_session, region, ami_config)
-                if default_channel not in images[region]:
-                    raise Exception("Unable to find default base AMI {} for region {}".format(default_channel, region))
-    return SharedData(images, trusted_addresses)
-
-
-def configure_account_except(session_data: AccountData, shared_data: SharedData):
-    try:
-        configure_account(session_data, shared_data)
-        return True
-    except Exception as e:
-        error(traceback.format_exc())
-        error(e)
-        return False
-
-
-def configure_account(session_data: AccountData, shared_data: SharedData):
-    start_time = time.time()
-    sevenseconds.helper.THREADDATA.name = session_data.name
-    session = {}
-    for session_name in ('session', 'admin_session', 'ami_session'):
-        session[session_name] = boto3.session.Session(**getattr(session_data, session_name))
-    account = session_data._replace(id=get_account_id(session['session']), **session)
-    del(session)
-    # Remove Default-Session
-    boto3.DEFAULT_SESSION = None
-    # account_id = get_account_id(session['account'])
-    # info('Account ID is {}'.format(account_id))
-    account_alias_from_aws = get_account_alias(account.session)
-    if len(account_alias_from_aws) == 0:
-        set_account_alias(account.session, account.alias)
-    elif account.alias != account_alias_from_aws[0]:
-        error('Connected to "{}", but account "{}" should be configured'.format(account_alias_from_aws, account.alias))
-        return
-
-    # check_policy_simulator exit this script with a fatal_error, if it found an error
-    check_policy_simulator(account)
-
-    configure_cloudtrail_all_regions(account)
-    dns_domain = configure_dns(account)
-    configure_iam(account, dns_domain)
-    configure_s3_buckets(account)
-
-    regions = account.config['regions']
-
-    futures = []
-    if len(regions) > 0:
-        with ThreadPoolExecutor(max_workers=len(regions)) as executor:
-            for region in regions:
-                futures.append(executor.submit(configure_account_region, account, region, shared_data))
-    for future in futures:
-        # will raise an exception if the jobs failed
-        future.result()
-    ok('Done with {} / {} after {}'.format(account.id, account.name, timedelta(seconds=time.time() - start_time)))
-
-
-def configure_account_region(account: object, region: str, shared_data: SharedData):
-    sevenseconds.helper.THREADDATA.name = '{}|{}'.format(account.name, region)
-
-    base_images = shared_data.base_images.get(region, {})
-    default_base_ami = base_images[account.config['base_ami']['default_channel']]
-
-    configure_log_group(account.session, region)
-    configure_acm(account, region)
-    configure_kms_keys(account, region)
-    configure_ebs_encryption(account, region)
-    configure_base_images(account, region, base_images)
-    vpc = configure_vpc(account, region, default_base_ami)
-    configure_bastion_host(account, vpc, region, default_base_ami)
-    configure_elasticache(account.session, region, vpc)
-    configure_rds(account.session, region, vpc)
-    configure_security_groups(account, region, shared_data.trusted_addresses, vpc)
-
-
-def start_cleanup(region: str, sessions: list, options: dict):
-    info('Start Pool processing...')
-    with Pool(processes=options.get('max_procs', os.cpu_count())) as pool:
-        pool.starmap(cleanup_account_except, zip(sessions.values(), repeat(region)))
-    info('Pool processing done... ')
-
-
-def cleanup_account_except(session_data: AccountData, region: str):
-    try:
-        cleanup_account(session_data, region)
-    except Exception as e:
-        error(traceback.format_exc())
-        error(e)
-
-
-def cleanup_account(session_data: AccountData, region: str):
-    start_time = time.time()
-    sevenseconds.helper.THREADDATA.name = session_data.name
-    session = {}
-    for session_name in ('session', 'admin_session', 'ami_session'):
-        session[session_name] = boto3.session.Session(**getattr(session_data, session_name))
-    account = session_data._replace(id=get_account_id(session['session']), **session)
-    del(session)
-    # Remove Default-Session
-    boto3.DEFAULT_SESSION = None
-    # account_id = get_account_id(session['account'])
-    # info('Account ID is {}'.format(account_id))
-
-    account_alias_from_aws = get_account_alias(account.session)
-    if len(account_alias_from_aws) > 0 and account.alias != account_alias_from_aws[0]:
-        error('Connected to "{}", but account "{}" should be configured'.format(account_alias_from_aws, account.alias))
-        return
-
-    cleanup_account_region(account, region)
-
-    ok('Done with {} / {} after {}'.format(account.id, account.name, timedelta(seconds=time.time() - start_time)))
-
-
-def cleanup_account_region(account: object, region: str):
-    sevenseconds.helper.THREADDATA.name = '{}|{}'.format(account.name, region)
-    if if_vpc_empty(account, region):
-        info('Region IS empty. Start clean up!')
-        if not account.dry_run:
-            delete_bastion_host(account, region)
-            delete_nat_host(account, region)
-            cleanup_vpc(account, region)
-    else:
-        error('Region is not empty. Skip clean up!')
-
-    # vpc = configure_vpc(account, region)
-    # configure_bastion_host(account, vpc, region)
-    # configure_elasticache(account.session, region, vpc)
-    # configure_rds(account.session, region, vpc)
-    # configure_security_groups(account, region, trusted_addresses)

--- a/sevenseconds/config/configure.py
+++ b/sevenseconds/config/configure.py
@@ -1,0 +1,186 @@
+import os
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+from itertools import repeat
+from multiprocessing import Pool
+
+import boto3
+
+import sevenseconds.helper
+from .acm import configure_acm
+from .ami import latest_base_images, configure_base_images
+from .bastion import configure_bastion_host, delete_bastion_host
+from .cloudtrail import configure_cloudtrail_all_regions
+from .cloudwatch import configure_log_group
+from .ec2 import configure_ebs_encryption
+from .elasticache import configure_elasticache
+from .iam import configure_iam
+from .kms import configure_kms_keys
+from .policysimulator import check_policy_simulator
+from .rds import configure_rds
+from .route53 import configure_dns
+from .s3 import configure_s3_buckets
+from .securitygroup import configure_security_groups
+from .vpc import configure_vpc, if_vpc_empty, cleanup_vpc, delete_nat_host
+from ..helper import error, info, ok
+from ..helper.aws import get_account_id, get_account_alias, set_account_alias
+from ..config import AccountData, SharedData
+
+
+def start_configuration(sessions: list, trusted_addresses: set, options: dict):
+    info('Start Pool processing...')
+
+    # TODO move trusted_addresses to prepare_shared_data
+    shared_data = prepare_shared_data(sessions, trusted_addresses)
+
+    with Pool(processes=options.get('max_procs', os.cpu_count())) as pool:
+        run_successfully = pool.starmap(configure_account_except, zip(sessions, repeat(shared_data)))
+    info('Pool processing done...')
+    if all(run_successfully):
+        return True
+    return False
+
+
+def prepare_shared_data(sessions: list, trusted_addresses: set):
+    """Returns the latest AMI IDs for each configured channel for all used regions"""
+    ami_session = boto3.session.Session(**sessions[0].ami_session)
+    ami_config = sessions[0].config['base_ami']
+    default_channel = ami_config['default_channel']
+
+    images = {}
+    for session in sessions:
+        if session.config['base_ami'] != ami_config:
+            raise Exception("base_ami config overrides are unsupported")
+
+        for region in session.config['regions']:
+            if region not in images:
+                images[region] = latest_base_images(ami_session, region, ami_config)
+                if default_channel not in images[region]:
+                    raise Exception("Unable to find default base AMI {} for region {}".format(default_channel, region))
+    return SharedData(images, trusted_addresses)
+
+
+def configure_account_except(session_data: AccountData, shared_data: SharedData):
+    try:
+        configure_account(session_data, shared_data)
+        return True
+    except Exception as e:
+        error(traceback.format_exc())
+        error(e)
+        return False
+
+
+def configure_account(session_data: AccountData, shared_data: SharedData):
+    start_time = time.time()
+    sevenseconds.helper.THREADDATA.name = session_data.name
+    session = {}
+    for session_name in ('session', 'admin_session', 'ami_session'):
+        session[session_name] = boto3.session.Session(**getattr(session_data, session_name))
+    account = session_data._replace(id=get_account_id(session['session']), **session)
+    del (session)
+    # Remove Default-Session
+    boto3.DEFAULT_SESSION = None
+    # account_id = get_account_id(session['account'])
+    # info('Account ID is {}'.format(account_id))
+    account_alias_from_aws = get_account_alias(account.session)
+    if len(account_alias_from_aws) == 0:
+        set_account_alias(account.session, account.alias)
+    elif account.alias != account_alias_from_aws[0]:
+        error('Connected to "{}", but account "{}" should be configured'.format(account_alias_from_aws, account.alias))
+        return
+
+    # check_policy_simulator exit this script with a fatal_error, if it found an error
+    check_policy_simulator(account)
+
+    configure_cloudtrail_all_regions(account)
+    configure_dns(account)
+    configure_iam(account)
+    configure_s3_buckets(account)
+
+    regions = account.config['regions']
+
+    futures = []
+    if len(regions) > 0:
+        with ThreadPoolExecutor(max_workers=len(regions)) as executor:
+            for region in regions:
+                futures.append(executor.submit(configure_account_region, account, region, shared_data))
+    for future in futures:
+        # will raise an exception if the jobs failed
+        future.result()
+    ok('Done with {} / {} after {}'.format(account.id, account.name, timedelta(seconds=time.time() - start_time)))
+
+
+def configure_account_region(account: object, region: str, shared_data: SharedData):
+    sevenseconds.helper.THREADDATA.name = '{}|{}'.format(account.name, region)
+
+    base_images = shared_data.base_images.get(region, {})
+    default_base_ami = base_images[account.config['base_ami']['default_channel']]
+
+    configure_log_group(account.session, region)
+    configure_acm(account, region)
+    configure_kms_keys(account, region)
+    configure_ebs_encryption(account, region)
+    configure_base_images(account, region, base_images)
+    vpc = configure_vpc(account, region, default_base_ami)
+    configure_bastion_host(account, vpc, region, default_base_ami)
+    configure_elasticache(account.session, region, vpc)
+    configure_rds(account.session, region, vpc)
+    configure_security_groups(account, region, shared_data.trusted_addresses, vpc)
+
+
+def start_cleanup(region: str, sessions: list, options: dict):
+    info('Start Pool processing...')
+    with Pool(processes=options.get('max_procs', os.cpu_count())) as pool:
+        pool.starmap(cleanup_account_except, zip(sessions.values(), repeat(region)))
+    info('Pool processing done... ')
+
+
+def cleanup_account_except(session_data: AccountData, region: str):
+    try:
+        cleanup_account(session_data, region)
+    except Exception as e:
+        error(traceback.format_exc())
+        error(e)
+
+
+def cleanup_account(session_data: AccountData, region: str):
+    start_time = time.time()
+    sevenseconds.helper.THREADDATA.name = session_data.name
+    session = {}
+    for session_name in ('session', 'admin_session', 'ami_session'):
+        session[session_name] = boto3.session.Session(**getattr(session_data, session_name))
+    account = session_data._replace(id=get_account_id(session['session']), **session)
+    del (session)
+    # Remove Default-Session
+    boto3.DEFAULT_SESSION = None
+    # account_id = get_account_id(session['account'])
+    # info('Account ID is {}'.format(account_id))
+
+    account_alias_from_aws = get_account_alias(account.session)
+    if len(account_alias_from_aws) > 0 and account.alias != account_alias_from_aws[0]:
+        error('Connected to "{}", but account "{}" should be configured'.format(account_alias_from_aws, account.alias))
+        return
+
+    cleanup_account_region(account, region)
+
+    ok('Done with {} / {} after {}'.format(account.id, account.name, timedelta(seconds=time.time() - start_time)))
+
+
+def cleanup_account_region(account: object, region: str):
+    sevenseconds.helper.THREADDATA.name = '{}|{}'.format(account.name, region)
+    if if_vpc_empty(account, region):
+        info('Region IS empty. Start clean up!')
+        if not account.dry_run:
+            delete_bastion_host(account, region)
+            delete_nat_host(account, region)
+            cleanup_vpc(account, region)
+    else:
+        error('Region is not empty. Skip clean up!')
+
+    # vpc = configure_vpc(account, region)
+    # configure_bastion_host(account, vpc, region)
+    # configure_elasticache(account.session, region, vpc)
+    # configure_rds(account.session, region, vpc)
+    # configure_security_groups(account, region, trusted_addresses)

--- a/sevenseconds/helper/auth.py
+++ b/sevenseconds/helper/auth.py
@@ -7,7 +7,6 @@ import botocore.exceptions
 import multiprocessing
 from itertools import repeat
 from ..helper import ActionOnExit, error, fatal_error
-from ..config import AccountData
 
 
 class AssumeRoleFailed(Exception):
@@ -262,6 +261,8 @@ def get_sessions(account_names: list,
 
 
 def rewrite_sessions_map(sessions_tmp: dict, credentials: dict, options: dict):
+    from ..config import AccountData
+
     sessions = {}
     for account_name in sessions_tmp:
         account_keyname = sessions_tmp[account_name]['account_keyname']

--- a/sevenseconds/helper/network.py
+++ b/sevenseconds/helper/network.py
@@ -95,9 +95,11 @@ def get_trusted_addresses(session_data, config: dict):
         if _cfg:
             cfg.update(_cfg)
         for region in cfg['regions']:
-            domains.update(['odd-{}.{}'.format(region, cfg.get('domain').format(account_name=account_name))])
-            for az in get_az_names(session, region):
-                domains.add('nat-{}.{}'.format(az, cfg.get('domain').format(account_name=account_name)))
+            dns_domain = cfg.get('domain')
+            if dns_domain:
+                domains.update(['odd-{}.{}'.format(region, dns_domain.format(account_name=account_name))])
+                for az in get_az_names(session, region):
+                    domains.add('nat-{}.{}'.format(az, dns_domain.format(account_name=account_name)))
 
     with multiprocessing.Pool(processes=os.cpu_count() * 20) as pool:
         addresses.update(pool.map(get_address, sorted(domains)))


### PR DESCRIPTION
If `account.domain` is set to `null`, don't manage DNS for account. This will not create DNS records for NAT GWs, the bastion host, or try to manage the certificate.

I tried improving the typing situation a bit (using proper types instead of `account: object` everywhere), which unfortunately necessitated moving stuff around to avoid circular imports. I didn't do a really good job at it, but I don't think this codebase can be improved incrementally.