### PR TITLE
Disable DNS cleanup

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -14,7 +14,7 @@ from .helper.regioninfo import get_regions
 from .config.configure import start_configuration, start_cleanup
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-SUPPORTED_CONFIG_VERSION = 2
+SUPPORTED_CONFIG_VERSION = 3
 
 
 def print_version(ctx, param, value):

--- a/sevenseconds/config/route53.py
+++ b/sevenseconds/config/route53.py
@@ -1,5 +1,4 @@
 from ..helper import ActionOnExit, error, info, warning
-from ..helper.aws import get_account_id
 from ..config import AccountData
 
 
@@ -40,9 +39,6 @@ def configure_dns(account: AccountData):
                                                           'TTL': int(soa_ttl),
                                                           'ResourceRecords': rr}}]}
         conn.change_resource_record_sets(HostedZoneId=zone['Id'], ChangeBatch=changebatch)
-
-    if (account.id == get_account_id(account.admin_session)):
-        cleanup_delegation(account)
 
 
 def configure_dns_delegation(admin_session: object, domain: str, nameservers: list, action: str = 'UPSERT'):


### PR DESCRIPTION
Some accounts rely on it, so let's disable it for now and fix it properly after the holidays.