### PR TITLE
Add a enable_nat config item which creates NAT gateways

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -14,7 +14,7 @@ from .helper.regioninfo import get_regions
 from .config.configure import start_configuration, start_cleanup
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-SUPPORTED_CONFIG_VERSION = 3
+SUPPORTED_CONFIG_VERSION = 4
 
 
 def print_version(ctx, param, value):


### PR DESCRIPTION
If an account has `enable_nat` set to false then sevenseconds will not create NAT for that account. Existing subnets and NATs won't be deleted. This config items is also `True` by default.