### PR TITLE
Resend renewal validation even if expiry is more than 4 weeks out

### DIFF
--- a/sevenseconds/config/acm.py
+++ b/sevenseconds/config/acm.py
@@ -31,6 +31,8 @@ def configure_acm(account: object, region):
                     cert = acm.describe_certificate(CertificateArn=cert_summary['CertificateArn'])['Certificate']
                     if cert['Status'] == 'PENDING_VALIDATION':
                         resend_validation_email(acm, cert)
+                    elif 'RenewalSummary' in cert and cert['RenewalSummary']['RenewalStatus'] == 'PENDING_VALIDATION':
+                        resend_validation_email(acm, cert)
                     elif cert['Status'] != 'ISSUED':
                         continue
                     elif (datetime.timedelta(weeks=4)

--- a/sevenseconds/config/securitygroup.py
+++ b/sevenseconds/config/securitygroup.py
@@ -13,8 +13,8 @@ def configure_security_groups(account: object, region: str, trusted_addresses: s
             update_security_group(account.session, region, sg_name, trusted_addresses)
 
 
-def chunks(l, n):
-    """ Yield successive n-sized chunks from l.
+def chunks(list, n):
+    """ Yield successive n-sized chunks from list.
     >>> a = chunks('a b c d e f g h i j k l m'.split(), 2)
     >>> a.__next__()
     ['a', 'b']
@@ -46,8 +46,8 @@ def chunks(l, n):
         ...
     StopIteration
     """
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
+    for i in range(0, len(list), n):
+        yield list[i:i + n]
 
 
 def consolidate_networks(networks: set, min_prefixlen: int):

--- a/sevenseconds/config/securitygroup.py
+++ b/sevenseconds/config/securitygroup.py
@@ -13,8 +13,8 @@ def configure_security_groups(account: object, region: str, trusted_addresses: s
             update_security_group(account.session, region, sg_name, trusted_addresses)
 
 
-def chunks(list, n):
-    """ Yield successive n-sized chunks from list.
+def chunks(collection, n):
+    """ Yield successive n-sized chunks from collection.
     >>> a = chunks('a b c d e f g h i j k l m'.split(), 2)
     >>> a.__next__()
     ['a', 'b']
@@ -46,8 +46,8 @@ def chunks(list, n):
         ...
     StopIteration
     """
-    for i in range(0, len(list), n):
-        yield list[i:i + n]
+    for i in range(0, len(collection), n):
+        yield collection[i:i + n]
 
 
 def consolidate_networks(networks: set, min_prefixlen: int):


### PR DESCRIPTION
This adds the case of resending a validation email if the renewal is pending (in addition to the top level pending case).

~~This wouldn't be covered by the 4 weeks expiry case because the cert is still `ISSUED` and therefore enters the `continue` block.~~
This would also eventually be covered by the 4 weeks expiry case below but seems that AWS marks them as pending already before. So let's just send those mails if there are pending renewals.

Note that `RenewalSummary` isn't present on all certs (gets added after first renewal I think) hence the `if in`.