### PR TITLE
Resend validation email 8 weeks before expiration instead of 4

### DIFF
--- a/sevenseconds/config/acm.py
+++ b/sevenseconds/config/acm.py
@@ -33,7 +33,7 @@ def configure_acm(account: object, region):
                         resend_validation_email(acm, cert)
                     elif cert['Status'] != 'ISSUED':
                         continue
-                    elif (datetime.timedelta(weeks=4)
+                    elif (datetime.timedelta(weeks=8)
                             > cert['NotAfter'] - datetime.datetime.now(cert['NotAfter'].tzinfo)):
                         renew_certificate(acm, cert)
                     domain_options = {}

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [flake8]
 max-line-length=120
+extend-ignore = E741
 # travis-ci.org allows only 1 job
 jobs=1


### PR DESCRIPTION
We currently trigger to resend validation emails via 7s [4 weeks before](https://github.com/zalando-stups/sevenseconds/blob/8dee87f11c0886a6bc0d20c376d2cfadcd16381f/sevenseconds/config/acm.py#L36) certificates are expiring.

AWS automatically starts sending out renewal emails 60 days before expiration for about two weeks ([source](https://aws.amazon.com/premiumsupport/knowledge-center/certificate-fails-to-auto-renew/)). After that it seems the first warning email is sent to users: for instance on Jun 2 we got an email for a certificate expiring on Jul 17 (45 days left).

Just to avoid unnecessary emails to our users let's resend emails via 7s before those 45 days as well.