### PR TITLE
IAM: add support for 'additional_policies'

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -14,7 +14,7 @@ from .helper.regioninfo import get_regions
 from .config.configure import start_configuration, start_cleanup
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-SUPPORTED_CONFIG_VERSION = 4
+SUPPORTED_CONFIG_VERSION = 5
 
 
 def print_version(ctx, param, value):

--- a/sevenseconds/config/securitygroup.py
+++ b/sevenseconds/config/securitygroup.py
@@ -13,7 +13,7 @@ def configure_security_groups(account: object, region: str, trusted_addresses: s
             update_security_group(account.session, region, sg_name, trusted_addresses)
 
 
-def chunks(l, n):
+def chunks(lst, n):
     """ Yield successive n-sized chunks from l.
     >>> a = chunks('a b c d e f g h i j k l m'.split(), 2)
     >>> a.__next__()
@@ -46,8 +46,8 @@ def chunks(l, n):
         ...
     StopIteration
     """
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
 
 
 def consolidate_networks(networks: set, min_prefixlen: int):

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1,0 +1,92 @@
+import pytest
+import sevenseconds.config.iam as iam
+
+
+SAMPLE_ROLES = {
+    "Shibboleth-Administrator": {
+        "policy": {
+            "Statement": [
+                {"Effect": "Allow", "Resource": "Test", "Action": "foo:*"},
+                {"Effect": "Deny", "Resource": "Test", "Action": "bar:*"},
+            ]
+        }
+    },
+    "Shibboleth-PowerUser": {
+        "policy": {
+            "Statement": [{"Effect": "Allow", "Resource": "Test", "Action": "baz:*"},]
+        }
+    },
+}
+
+SAMPLE_POLICIES = [
+    {
+        "role": "Shibboleth-Administrator",
+        "statement": {"Effect": "Allow", "Resource": "Additional", "Action": "test:*"},
+    },
+    {
+        "role": "Shibboleth-Administrator",
+        "statement": {"Effect": "Deny", "Resource": "Additional", "Action": "abc:*"},
+    },
+]
+
+
+def test_effective_policies_merge():
+    config = {
+        "roles": SAMPLE_ROLES,
+        "additional_policies": SAMPLE_POLICIES,
+    }
+    expected = {
+        "Shibboleth-Administrator": {
+            "policy": {
+                "Statement": [
+                    {"Effect": "Allow", "Resource": "Test", "Action": "foo:*"},
+                    {"Effect": "Deny", "Resource": "Test", "Action": "bar:*"},
+                    {"Effect": "Allow", "Resource": "Additional", "Action": "test:*"},
+                    {"Effect": "Deny", "Resource": "Additional", "Action": "abc:*"},
+                ]
+            }
+        },
+        "Shibboleth-PowerUser": {
+            "policy": {
+                "Statement": [
+                    {"Effect": "Allow", "Resource": "Test", "Action": "baz:*"},
+                ]
+            }
+        },
+    }
+
+    assert expected == iam.effective_roles(config)
+
+    # check that the original config was not affected
+    assert 2 == len(config["roles"]["Shibboleth-Administrator"]["policy"]["Statement"])
+
+
+@pytest.mark.parametrize(
+    "roles",
+    [
+        # Dropped role
+        {"Shibboleth-Administrator": {"drop": True}},
+        # Missing role
+        {
+            "Shibboleth-PowerUser": {
+                "policy": {
+                    "Statement": [
+                        {"Effect": "Allow", "Resource": "Test", "Action": "baz:*"},
+                    ]
+                }
+            }
+        },
+        # No policy
+        {"Shibboleth-Administrator": {}},
+        # Policy but no statement
+        {"Shibboleth-Administrator": {"policy": {}}},
+    ],
+)
+def test_effective_policies_fail_invalid(roles):
+    config = {
+        "roles": roles,
+        "additional_policies": SAMPLE_POLICIES,
+    }
+
+    with pytest.raises(ValueError):
+        iam.effective_roles(config)


### PR DESCRIPTION
This allows extending roles with ad-hoc policy statements so we don't need to duplicate 5 levels of configuration for a particular account.