### PR TITLE
CloudTrail: drop Lambda events

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -14,7 +14,7 @@ from .helper.regioninfo import get_regions
 from .config.configure import start_configuration, start_cleanup
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-SUPPORTED_CONFIG_VERSION = 5
+SUPPORTED_CONFIG_VERSION = 6
 
 
 def print_version(ctx, param, value):

--- a/sevenseconds/config/cloudtrail.py
+++ b/sevenseconds/config/cloudtrail.py
@@ -103,14 +103,7 @@ def configure_cloudtrail(account: object):
                     {
                         'ReadWriteType': 'All',
                         'IncludeManagementEvents': True,
-                        'DataResources': [
-                            {
-                                'Type': 'AWS::Lambda::Function',
-                                'Values': [
-                                    'arn:aws:lambda',
-                                ]
-                            },
-                        ]
+                        'DataResources': [],
                     },
                 ]
             )


### PR DESCRIPTION
These create a lot of events that we don't actually need. Version bumped to prevent users from running a version of 7s that would restore this.