### PR TITLE
Update PyJWT usage, specify an explicit range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ python-gnupg>=0.3.7
 python-dateutil
 datetime
 PyYAML
-PyJWT>=1.4.2
+PyJWT>=2.0, <3.0
 stups-zign>=1.1.26
 setuptools>=30

--- a/sevenseconds/helper/auth.py
+++ b/sevenseconds/helper/auth.py
@@ -34,7 +34,7 @@ class OAuthServices:
         self.service_resources = aws_credentials_service_resources
         self.account_list_url = account_list_url
         self.token_managed_id_key = token_managed_id_key
-        self.decoded_token = jwt.decode(self.token, verify=False)
+        self.decoded_token = jwt.decode(token, options={"verify_signature": False})
 
         if self.token_managed_id_key not in self.decoded_token:
             raise ValueError('Invalid token. Please check your ztoken configuration')


### PR DESCRIPTION
Existing usage is incompatible with pyjwt==2.0, and requirements.txt didn't prevent it from getting installed.