### PR TITLE
Add option to disable odd per account

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -14,7 +14,7 @@ from .helper.regioninfo import get_regions
 from .config.configure import start_configuration, start_cleanup
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-SUPPORTED_CONFIG_VERSION = 6
+SUPPORTED_CONFIG_VERSION = 7
 
 
 def print_version(ctx, param, value):


### PR DESCRIPTION
With more accounts in Kubernetes and other soltions like EC2 Instance
Connect odd hosts are not needed. This commit creates the `enable_odd`
config that defaults to `True` and enable us to disable this feature per
account. If odd instances are found and it's disabled it will be
removed while in new accounts it won't be created.