### PR TITLE
Support attaching/detaching policies to managed roles

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -14,7 +14,7 @@ from .helper.regioninfo import get_regions
 from .config.configure import start_configuration, start_cleanup
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-SUPPORTED_CONFIG_VERSION = 7
+SUPPORTED_CONFIG_VERSION = 8
 
 
 def print_version(ctx, param, value):

--- a/sevenseconds/config/iam.py
+++ b/sevenseconds/config/iam.py
@@ -84,10 +84,10 @@ def configure_iam_policy(account: AccountData):
 
             expected_policy_document = json.loads(
                 json.dumps(role_cfg.get('policy')).replace('{account_id}', account.id))
+            expected_policies = {role_name: expected_policy_document} if expected_policy_document else {}
             policies = {p.policy_name: p.policy_document for p in role.policies.all()}
-            expected_policies = {role_name: expected_policy_document}
             if policies != expected_policies:
-                with ActionOnExit('Updating policy for role {role_name}..', **vars()):
+                with ActionOnExit('Updating policy for role {role_name}..', **vars()) as act:
                     for name, document in expected_policies.items():
                         iam.RolePolicy(role_name, name).put(PolicyDocument=json.dumps(document))
                     for policy_name in policies:


### PR DESCRIPTION
This adds support for the `attached_policies` field in a role definition, which is a list of managed policy ARNs that should be attached to the role. This supports both AWS-managed policies (`arn:aws:iam::aws:policy/…`) and customer-managed policies using the standard `{account_id}` interpolation (`arn:aws:iam::{account_id}:policy/…`). Additionally, refactor the role management code a bit to make it slightly more clear what's going on.

Note that there's still no support for managing the policies yet, but it should be fairly easy to add in the future and could simplify our account config.