### PR TITLE
Fixes var declaration.

### DIFF
--- a/sevenseconds/config/vpc.py
+++ b/sevenseconds/config/vpc.py
@@ -520,6 +520,7 @@ def configure_routing_table(vpc: object, nat_instance_by_az: dict, replace_defau
             if get_tag(rt.tags, 'Name', 'undef-rt-name') == get_tag(subnet.tags, 'Name', 'undef-subnet-name'):
                 route_table = rt
                 break
+        destination = None
         if route_via_igw:
             for igw in vpc.internet_gateways.all():
                 destination = {'GatewayId': igw.id}


### PR DESCRIPTION
7s was failing with:

```
ERRO[2021-04-26T15:43:06.484527602+02:00] sevenseconds run #6 | UnboundLocalError: local variable 'destination' referenced before assignment
```

Signed-off-by: rreis <rodrigo@zalando.de>