### PR TITLE
Create additional_attached_policies config

### DIFF
--- a/sevenseconds/cli.py
+++ b/sevenseconds/cli.py
@@ -14,7 +14,7 @@ from .helper.regioninfo import get_regions
 from .config.configure import start_configuration, start_cleanup
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-SUPPORTED_CONFIG_VERSION = 8
+SUPPORTED_CONFIG_VERSION = 9
 
 
 def print_version(ctx, param, value):


### PR DESCRIPTION
This commit adds an `additional_attached_policies` config for the
accounts. It allows to define additional policies that will be attached
to the specified roles. If none is set, the default role config is used.

Signed-off-by: Jonathan Juares Beber <jonathanbeber@gmail.com>