### PR TITLE
Disable odd host by default

### DIFF
--- a/sevenseconds/config/bastion.py
+++ b/sevenseconds/config/bastion.py
@@ -19,7 +19,7 @@ def configure_bastion_host(account: AccountData, vpc: object, region: str, base_
     cf = account.session.resource('cloudformation', region)
     cfc = account.session.client('cloudformation', region)
 
-    enable_bastion = account.config.get("enable_odd", True)
+    enable_bastion = account.config.get("enable_odd", False)
     re_deploy = account.config['bastion'].get('re_deploy', account.options.get('redeploy_odd_host'))
 
     bastion_version = None


### PR DESCRIPTION
We are working on reducing the number of odd hosts and thus it's more convenient to disable by default. We will explicitly opt-in for the accounts where it should still be enabled.