### PR TITLE
Support setting vpc flow log retention time

### DIFF
--- a/sevenseconds/config/cloudwatch.py
+++ b/sevenseconds/config/cloudwatch.py
@@ -1,7 +1,17 @@
-def configure_log_group(session: object, region: str):
-    client = session.client('logs', region)
-    logs = client.describe_log_groups(logGroupNamePrefix='vpc-flowgroup')['logGroups']
+def configure_log_group(session: object, region: str, config: dict):
+    retention_in_days = config.get("vpc", {}).get("flow_logs_retention_in_days", 3653)
+    client = session.client("logs", region)
+    logs = client.describe_log_groups(logGroupNamePrefix="vpc-flowgroup")["logGroups"]
     for log in logs:
-        if log.get('logGroupName', '') == 'vpc-flowgroup':
+        if log.get("logGroupName", "") == "vpc-flowgroup":
+            if log.get("retentionInDays", 0) != retention_in_days:
+                client.put_retention_policy(
+                    logGroupName="vpc-flowgroup",
+                    retentionInDays=retention_in_days,
+                )
             return
-    client.create_log_group(logGroupName='vpc-flowgroup')
+    client.create_log_group(logGroupName="vpc-flowgroup")
+    client.put_retention_policy(
+        logGroupName="vpc-flowgroup",
+        retentionInDays=retention_in_days,
+    )

--- a/sevenseconds/config/configure.py
+++ b/sevenseconds/config/configure.py
@@ -118,7 +118,7 @@ def configure_account_region(account: object, region: str, shared_data: SharedDa
     base_images = shared_data.base_images.get(region, {})
     default_base_ami = base_images[account.config['base_ami']['default_channel']]
 
-    configure_log_group(account.session, region)
+    configure_log_group(account.session, region, account.config)
     configure_acm(account, region)
     configure_kms_keys(account, region)
     configure_ebs_encryption(account, region)


### PR DESCRIPTION
Add support for setting a retention time on the log group used for vpc flow logs.

If nothing is specified in the config file it will default to `3653` days (10 years) which is the highest retention in days if you don't specify _never expire_ which was the default for us so far.

The idea would be to set this to a lower value as per our internal requirements.